### PR TITLE
Fix Bug: PackageCheck() deprecated in SeuratObject 5.0.0 in the `02_run_scDblFinder.Rmd`

### DIFF
--- a/analyses/upstream-analysis/02_run_scDblFinder.Rmd
+++ b/analyses/upstream-analysis/02_run_scDblFinder.Rmd
@@ -192,6 +192,7 @@ if (!dir.exists(scDblFinder_plots_dir)) {
   dir.create(scDblFinder_plots_dir)}
 
 source(paste0(root_dir, "/figures/scripts/theme_plot.R"))
+source(paste0(analysis_dir, "/util/function-create-sce-seurat-object.R"))
 ```
 
 # Read metadata file and define `sample_name`
@@ -239,8 +240,15 @@ for (i in seq_along(sample_name)) {
     RunSVD %>%
     RunUMAP(reduction = "lsi", dims = 2:30)
 
-  sce_obj_list[[i]] <- as.SingleCellExperiment(sce_obj_list[[i]])
-  
+  #sce_obj_list[[i]] <- as.SingleCellExperiment(sce_obj_list[[i]])
+  # Build an SCE in-place (no as.SingleCellExperiment, no slot= calls):
+  sce_obj_list[[i]] <- seurat_to_sce_safe(so = sce_obj_list[[i]],
+                                          assay = assay,
+                                          counts_layer  = "counts",  # raw counts for scDblFinder
+                                          expr_layer    = "data")     # e.g., normalized matrix -> stored in 'logcounts'
+
+ 
+
   ###############################################################
   cat("Beginning to run scDblFinder for sample", sample_name[i], "\n")
   # -------------------------------------------------------------------------------------------
@@ -319,10 +327,19 @@ for (i in seq_along(sample_name)) {
   doublets_to_filter <- subset(doublets, doublets$scDblFinder.class == "doublet") 
   
   # Convert sce list into seurat list
-  seurat_obj_with_doublets_list[[i]] <- as.Seurat(sce_obj_list[[i]], 
-                                        counts = "counts", 
-                                        data = "logcounts") 
-  
+  #seurat_obj_with_doublets_list[[i]] <- as.Seurat(sce_obj_list[[i]], 
+  #                                      counts = "counts", 
+  #                                      data = "logcounts") 
+  seurat_obj_with_doublets_list[[i]] <- sce_to_seurat_safe(
+      sce            = sce_obj_list[[i]],
+      assay_name     = assay,        # e.g., "peaks"
+      data_from      = "logcounts",  # put SCE's logcounts into Seurat's "data"
+      add_reductions = TRUE)
+  umap_mat <- Seurat::Embeddings(seurat_obj_with_doublets_list[[i]], "umap")
+  reducedDim(sce_obj_list[[i]], "UMAP") <- umap_mat
+
+
+
   ########################################################################################################
   # Plot the Doublets predictions on the UMAP
   cat("Plotting doublets predictions on the UMAP for sample:", sample_name[i], "\n")

--- a/analyses/upstream-analysis/util/function-create-sce-seurat-object.R
+++ b/analyses/upstream-analysis/util/function-create-sce-seurat-object.R
@@ -1,0 +1,222 @@
+########################################################################################################
+#' -- internal utility: version check
+#' --- Replace the old .is_SO_v5() with this robust version ---
+
+#suppressPackageStartupMessages({
+#  library(SingleCellExperiment)
+#  library(SummarizedExperiment)
+#  library(Matrix)
+#})
+
+.is_SO_v5 <- function() {
+  v <- utils::packageVersion("SeuratObject")
+  # Convert to character like "5.0.1", split on '.', take first token, coerce to integer
+  maj <- as.integer(strsplit(as.character(v), "\\.")[[1L]][1L])
+  isTRUE(maj >= 5L)
+}
+########################################################################################################
+
+
+########################################################################################################
+#' -- internal utility: read a matrix by layer/slot depending on SeuratObject major version
+.get_mat <- function(so, assay, layer_or_slot, prefer_layer = TRUE) {
+  if (.is_SO_v5()) {
+    # SeuratObject v5+: must use 'layer='
+    return(Seurat::GetAssayData(so, assay = assay, layer = layer_or_slot))
+  } else {
+    # SeuratObject v4.x: use 'slot='; translate common layer names to matching slots
+    slot_name <- switch(
+      layer_or_slot,
+      "counts"      = "counts",
+      "data"        = "data",
+      "scale.data"  = "scale.data",
+      layer_or_slot # pass through (for unusual names)
+    )
+    return(Seurat::GetAssayData(so, assay = assay, slot = slot_name))
+  }
+}
+########################################################################################################
+
+
+########################################################################################################
+#' Convert a Seurat object to SingleCellExperiment without using as.SingleCellExperiment()
+#'
+#' @param so            A Seurat object.
+#' @param assay         Character scalar; assay name to pull matrices from. Defaults to DefaultAssay(so).
+#' @param counts_layer  Character scalar; which layer to use as counts assay in SCE (e.g. "counts").
+#' @param expr_layer    Character scalar; optional expression/normalized layer to add as 'logcounts'
+#'                       (e.g. "data"). Set NULL to skip.
+#' @param add_reductions Logical; copy Seurat reductions into SCE reducedDims. Default TRUE.
+#'
+#' @return A SingleCellExperiment with assays(counts=...), optional logcounts, colData, rowData, reducedDims.
+seurat_to_sce_safe <- function(
+    so,
+    assay         = NULL,
+    counts_layer  = "counts",
+    expr_layer    = "data",
+    add_reductions = TRUE) {
+  if (is.null(assay)) assay <- Seurat::DefaultAssay(so)
+  
+  # Validate that requested layers exist on the assay when on v5
+  if (.is_SO_v5()) {
+    lyr_avail <- tryCatch(SeuratObject::Layers(so[[assay]]), error = function(e) character(0))
+    if (!(counts_layer %in% lyr_avail)) {
+      stop(sprintf("Layer '%s' not found in assay '%s'. Available: %s",
+                   counts_layer, assay, paste(lyr_avail, collapse = ", ")), call. = FALSE)
+    }
+    if (!is.null(expr_layer) && !(expr_layer %in% lyr_avail)) {
+      warning(sprintf("Expr layer '%s' not found; will skip logcounts. Available: %s",
+                      expr_layer, paste(lyr_avail, collapse = ", ")))
+      expr_layer <- NULL
+    }
+  }
+  
+  # ---- counts matrix (required by scDblFinder)
+  m_counts <- .get_mat(so, assay = assay, layer_or_slot = counts_layer)
+  if (!inherits(m_counts, "dgCMatrix")) m_counts <- as(m_counts, "dgCMatrix")
+  
+  # ---- colData from meta.data (align to cell order)
+  cells <- colnames(so)
+  meta  <- so@meta.data
+  cd <- DataFrame(meta[cells, , drop = FALSE])
+  
+  # ---- rowData (lightweight)
+  rd <- DataFrame(row.names = rownames(m_counts))
+  rd$feature <- rownames(m_counts)
+  
+  sce <- SingleCellExperiment(
+    assays  = list(counts = m_counts),
+    colData = cd,
+    rowData = rd
+  )
+  
+  # ---- optional expression layer -> logcounts
+  if (!is.null(expr_layer)) {
+    m_expr <- .get_mat(so, assay = assay, layer_or_slot = expr_layer)
+    if (!inherits(m_expr, "dgCMatrix")) m_expr <- as(m_expr, "dgCMatrix")
+    # keep shapes aligned to cells/rows
+    m_expr <- m_expr[rownames(sce), colnames(sce), drop = FALSE]
+    SummarizedExperiment::assay(sce, "logcounts") <- m_expr
+  }
+  
+  # ---- reducedDims (optional)
+  if (isTRUE(add_reductions) && length(so@reductions)) {
+    rd_list <- list()
+    for (red in names(so@reductions)) {
+      emb <- try(Seurat::Embeddings(so[[red]]), silent = TRUE)
+      if (!inherits(emb, "try-error")) {
+        # Embeddings rows are cells; align to SCE columns
+        common <- intersect(rownames(emb), colnames(sce))
+        if (length(common)) {
+          rd_list[[red]] <- as.matrix(emb[common, , drop = FALSE])[colnames(sce), , drop = FALSE]
+        }
+      }
+    }
+    if (length(rd_list)) {
+      reducedDims(sce) <- rd_list
+    }
+  }
+  
+  sce
+}
+########################################################################################################
+
+
+
+########################################################################################################
+# --- dependencies
+#suppressPackageStartupMessages({
+#  library(Seurat)
+#  library(SeuratObject)
+#  library(SingleCellExperiment)
+#  library(SummarizedExperiment)
+#  library(Matrix)
+#})
+
+# --- set "data" (or any name) into an Assay using the right API for v4/v5
+.set_data_matrix <- function(assay_obj, mat, name = "data") {
+  if (!inherits(mat, "dgCMatrix")) mat <- as(mat, "dgCMatrix")
+  if (.so_is_v5()) {
+    # v5+: write into a layer
+    assay_obj <- SeuratObject::SetAssayData(object = assay_obj, layer = name, new.data = mat)
+  } else {
+    # v4.x: write into a slot
+    assay_obj <- SeuratObject::SetAssayData(object = assay_obj, slot  = name, new.data = mat)
+  }
+  assay_obj
+}
+########################################################################################################
+
+
+########################################################################################################
+#' Convert SingleCellExperiment to Seurat without using as.Seurat()
+#'
+#' @param sce         A SingleCellExperiment with at least a "counts" assay.
+#' @param assay_name  Name for the Seurat assay to create (e.g., "peaks", "RNA").
+#' @param data_from   SCE assay to copy into Seurat "data" (default "logcounts").
+#'                    Use NULL to skip; if not found, falls back to log1p(counts).
+#' @param add_reductions  If TRUE, copy reducedDims to Seurat reductions.
+#' @return A Seurat object.
+sce_to_seurat_safe <- function(sce, assay_name = "RNA", data_from = "logcounts", add_reductions = TRUE) {
+  stopifnot(inherits(sce, "SingleCellExperiment"))
+  
+  ## 1) counts (required)
+  if (!"counts" %in% SummarizedExperiment::assayNames(sce)) {
+    stop("SCE must contain a 'counts' assay.", call. = FALSE)
+  }
+  counts_mat <- SummarizedExperiment::assay(sce, "counts")
+  if (!inherits(counts_mat, "dgCMatrix")) counts_mat <- as(counts_mat, "dgCMatrix")
+  
+  ## 2) create base Seurat object (this places counts in the assay already)
+  so <- Seurat::CreateSeuratObject(
+    counts   = counts_mat,
+    assay    = assay_name,
+    meta.data = as.data.frame(SummarizedExperiment::colData(sce))
+  )
+  
+  ## 3) optional "data" matrix
+  if (!is.null(data_from)) {
+    if (data_from %in% SummarizedExperiment::assayNames(sce)) {
+      data_mat <- SummarizedExperiment::assay(sce, data_from)
+    } else {
+      # fallback: compute a simple log1p of counts if requested layer not present
+      message("Assay '", data_from, "' not found in SCE; using log1p(counts) as 'data'.")
+      data_mat <- as.matrix(Matrix::t(Matrix::t(counts_mat))) # keep sparse-friendly; we’ll log1p below
+      data_mat <- as(data_mat, "dgCMatrix")
+      data_mat@x <- log1p(data_mat@x)
+    }
+    # align to Seurat feature/cell order
+    data_mat <- data_mat[rownames(so), colnames(so), drop = FALSE]
+    # write to the assay using version-aware setter
+    so[[assay_name]] <- .set_data_matrix(so[[assay_name]], data_mat, name = "data")
+  }
+  
+  ## 4) reduced dimensions
+  if (isTRUE(add_reductions) && length(SingleCellExperiment::reducedDims(sce)) > 0) {
+    for (nm in names(SingleCellExperiment::reducedDims(sce))) {
+      emb <- SingleCellExperiment::reducedDims(sce)[[nm]]
+      # ensure rownames exist and align to cells
+      if (is.null(rownames(emb))) {
+        # try to infer from colnames(sce) length; if mismatch, skip
+        if (nrow(emb) == ncol(so)) {
+          rownames(emb) <- colnames(so)
+        } else {
+          warning("ReducedDim '", nm, "' has no rownames; skipping.")
+          next
+        }
+      }
+      common <- intersect(rownames(emb), colnames(so))
+      if (!length(common)) next
+      emb <- emb[colnames(so), , drop = FALSE]  # reorder to Seurat cells
+      so[[nm]] <- Seurat::CreateDimReducObject(
+        embeddings = as.matrix(emb),
+        key        = paste0(toupper(nm), "_"),
+        assay      = assay_name
+      )
+    }
+  }
+  
+  so
+}
+########################################################################################################
+


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

<!-- Check all those that apply or remove this section if it is not applicable.-->

# Purpose/implementation Section

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## What scientific question/module of analysis is your analysis addressing?

There is a similar bug coming up in the 02_run_scDblFinder.Rmd in the upstream-analysis module. For more details, see:

```
Error:
! `PackageCheck()` was deprecated in SeuratObject 5.0.0 and is now defunct.
i Please use `rlang::check_installed()` instead.
Backtrace:
    x
 1. +-Seurat::as.SingleCellExperiment(sce_obj_list[[i]])
 2. \-Seurat:::as.SingleCellExperiment.Seurat(sce_obj_list[[i]])
 3.   \-SeuratObject::PackageCheck("SingleCellExperiment", error = FALSE)
 4.     \-SeuratObject::.Deprecate(...)
 5.       \-lifecycle::deprecate_stop(...)
 6.         \-lifecycle:::deprecate_stop0(msg)
 7.           \-rlang::cnd_signal(...)

Quitting from 02_run_scDblFinder.Rmd:215-350 [run-recoverDoublets-plot-predictions]
```

I will be creating a function to bypass this issue.

## What GitHub issue does your pull request address?

Closes #113.


## Directions for reviewers 
Tell potential reviewers what kind of feedback you are soliciting.

### Which areas should receive a particularly close look?

- [ ] Review for code logic and clarity.
- [ ] Test the module with LSF by using the testing cohort -> Run only script 2.
- [ ] Test the module in an interactive session by using the testing cohort -> Run only script 2.


## Reproducibility Checklist

- [x] The dependencies required to run the code in this pull request have been added to the project Dockerfile.

## Documentation Checklist


- [x] This analysis module has a `README` and it is up to date.
- [x] The analytical code is documented and contains comments.
