### PR TITLE
Fix bug for AnnotationHub to run GRCh38 genome reference cohorts

### DIFF
--- a/analyses/upstream-analysis/README.md
+++ b/analyses/upstream-analysis/README.md
@@ -61,10 +61,10 @@ Moreover, only libraries with more than 500 cells will be kept for merging and i
 
 We need tp assign gene annotations from EnsDb based on the genome reference used for the cohort. For more information on the various Ensembl releases, you can refer to the [Table of Assemblies](https://useast.ensembl.org/info/website/archives/assembly.html) and [Build Notes for Reference Packages](https://www.10xgenomics.com/support/software/cell-ranger/downloads/cr-ref-build-steps#ref-2020-a).
 
-| Species | Genome Build | Ensembl Version(s)        | Annotation Package                              |
+| Species | Genome Build | Ensembl Version(s)        | Annotation Package                               |
 |---------|--------------|---------------------------|--------------------------------------------------|
-| Human   | hg19 (GRCh37) | v75                       | `EnsDb.Hsapiens.v75`                             |
-| Human   | hg38 (GRCh38) | v86 (older), v98 (newer)  | `EnsDb.Hsapiens.v86`, `EnsDb.Hsapiens.v98`       |
+| Human   | hg19 (GRCh37) | -                        |        -                     |
+| Human   | hg38 (GRCh38) | v108                     | `EnsDb.Hsapiens.v108`                            |
 | Mouse   | mm9 (NCBI37)  | —                         | *No official* `EnsDb`; use `TxDb.Mmusculus.UCSC.mm9.knownGene` |
 | Mouse   | mm10 (GRCm38) | v79                       | `EnsDb.Mmusculus.v79`                            |
 | Mouse   | mm39 (GRCm39) | v104, v105                | `EnsDb.Mmusculus.v104`, `EnsDb.Mmusculus.v105`   |

--- a/project_parameters.Config.yaml
+++ b/project_parameters.Config.yaml
@@ -3,7 +3,7 @@ root_dir: "/sc-epigenie" # Absolute path to the main dir of the project where Gi
 data_dir: "/sc-epigenie/analyses/cellranger-analysis/results/02_cellranger_count/DefaultParameters" # Absolute path to data dir of the project with CellRanger output results. Options: "DefaultParameters", "ForcedCells8000Parameters", or else. 
 metadata_dir: "/data/project_metadata" # Absolute path to metadata dir of the project.
 metadata_file: "project_metadata.tsv" # Options: "project_metadata.tsv" (default) or name as user wants. It needs to be in `tsv` format. It can include one or more samples, as long as it contains at least the following columns in this exact order: `ID`, `SAMPLE`, and `FASTQ`. The `ID` column must contain unique values. Additional metadata columns can be added and arranged as needed by the user (though not required). For samples with multiple technical replicates, list all associated FASTQ file paths in the same row, using commas to separate each path.
-genome_name: "GRCh38" # define genome reference and versioning. Options: (1) human: "GRCh38" and "hg19"; and (2) mouse: "GRCm39", "mm10", and "mm9".
+genome_name: "GRCm39" # define genome reference and versioning. Options: (1) human: "GRCh38" and "hg19"; and (2) mouse: "GRCm39", "mm10", and "mm9".
 PROJECT_NAME: "Victoria_Knockout - Testing cohort"
 PI_NAME: "Michael A. Dyer, PhD"
 TASK_ID: "NA"
@@ -24,7 +24,7 @@ COMPLETION_DATE: "ONGOING"
 # `./analyses/cellranger-analysis`
 genome_reference_path: "./reference_genomes/cellranger-sc-atac-seq/2020-A/mus_musculus/mm10/downloads/refdata-cellranger-arc-mm10-2020-A-2.0.0" # Absolute path to genome reference to be used for the `cellranger-analysis` module.
 cellranger_parameters: "DefaultParameters" # Options: "DefaultParameters", "ForcedCells8000Parameters", or else.
-genome_name_cellranger: "GRCh38" #please define the genome of preference for dual genomes. In case for single genomes, please use the same as used for `genome_name`.
+genome_name_cellranger: "GRCm39" #please define the genome of preference for dual genomes. In case for single genomes, please use the same as used for `genome_name`.
 # Define the sample ID prefix(es) used in this project.
 # Sample IDs should follow a format like: PREFIX001 (e.g., DYE001, ABC002).
 # You can specify multiple prefixes if your project uses more than one.
@@ -34,13 +34,13 @@ sample_prefix:
   - XYZ_
 
 # `./analyses/upstream-analysis`
-genome_name_upstream: "GRCh38" # Options: (1) human: "GRCh38" and "hg19"; and (2) mouse: "GRCm39", "mm10", and "mm9".
+genome_name_upstream: "GRCm39" # Options: (1) human: "GRCh38" and "hg19"; and (2) mouse: "GRCm39", "mm10", and "mm9".
 assay_signac_qc: "peaks" # Options: "peaks" (default ALWAYS)
 # Genome-to-Ensembl Mapping Options: (1) human: "GRCh38" -> "EnsDb.Hsapiens.v108" | "hg19" -> "EnsDb.Hsapiens.v75"
 #                                    (2) mouse: "GRCm39" -> "EnsDb.Mmusculus.v104" (or "EnsDb.Mmusculus.v105"), | "mm10" -> "EnsDb.Mmusculus.v79" and  | "mm9" -> No official `EnsDb` package, use "TxDb.Mmusculus.UCSC.mm9.knownGene" or similar
-annotation_Ensembl_upstream: "EnsDb.Hsapiens.v108" 
-species_upstream: "Homo sapiens" # Options: "Homo sapiens"; "Mus musculus"
-object_species_upstream: "AH109336" # Reference genome annotation ID. This needs to match the `annotation_Ensembl_upstream` as it is available in the AnnotationHub. 
+annotation_Ensembl_upstream: "EnsDb.Mmusculus.v104" 
+species_upstream: "Mus musculus" # Options: "Homo sapiens"; "Mus musculus"
+object_species_upstream: "AH95775" # Reference genome annotation ID. This needs to match the `annotation_Ensembl_upstream` as it is available in the AnnotationHub. 
                                     # Options: (1) human: "GRCh38" -> "AH109336" ("EnsDb.Hsapiens.v108")
                                     #          (2) mouse: "GRCm39" -> "AH95775" ("EnsDb.Mmusculus.v104")
 min.cutoff_value_upstream: "q0" # Options: e.g., "q0" to use all peaks; "q75" to use the top 25% all peaks; "q95" to use the top 5% all peaks and so on.


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

<!-- Check all those that apply or remove this section if it is not applicable.-->

# Purpose/implementation Section

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## What scientific question/module of analysis is your analysis addressing?

This addresses the issue related to the following issue of the `01A_run_signac_qc.Rmd` in the `upstream-analysis` module, as reported in #107.

- Bug: AnnotationHub cannot resolve object_species (GRCh38) — ah[[...]] throws “record not found in database” in Signac QC


## What GitHub issue does your pull request address?

Closes #107.


## Directions for reviewers 
Tell potential reviewers what kind of feedback you are soliciting.

### Which areas should receive a particularly close look?

@ashajacobjannu, there were two issues here in the YAML file with the following variables:

1. species_upstream: "Homo sapiens" 

    - The value should be "Homo sapiens", not "Hsapiens". This is now updated in the YAML file accordingly.


2. object_species_upstream: "AH109336" 

    - This parameter must be an AnnotationHub ID (e.g., "AH109336") rather than a genome build name such as "GRCh38". Based on your YAML snapshot, it looks like "GRCh38" was used, which is not valid for ah[[...]] indexing. 


 <img width="1203" height="66" alt="Image" src="https://github.com/user-attachments/assets/a2f0770d-69dc-4a35-8c2a-ecd75a2046e1" />


   - In addition, the `annotation_Ensembl_upstream` and `object_species_upstream` need to be the correct match available in the AnnotationHub. In the case, for genome_name_upstream: "GRCh38", it has to be `annotation_Ensembl_upstream: "EnsDb.Hsapiens.v108" ` with `object_species_upstream: "AH109336"`. I added new values and documentation in the YAML. Any other combinations are hard to suggest as they will need to be tested. This should suffice for now.
 

#### Next steps -TESTING

For testing purposes, please do the following:

- [ ] 1. Use the original code in the `01A_run_signac_qc.Rmd` script.
- [ ] 2. Use the THRB2-10x-multiome data - [stjude-dnb-binfcore/sc-epigenie-test-multiome-data](https://github.com/stjude-dnb-binfcore/sc-epigenie-test-multiome-data) 
- [ ] 3. Pull the epigenie container again. I have updated the current image to the previous version that was working (October 11, 2025).
- [ ] 4. Update the YAML file with the correct combination of the `AnnotationHub ID` and `object_species_upstream`. See the current YAML for suggested values.

- [ ] 5. Review the YAML file for code and documentation logic.
- [ ] 6. Confirm a successful run of the test cohort of the `01A_run_signac_qc.Rmd` script.

### Is there anything that you want to discuss further?

The proposed code modification at #107 is the same as the existing script logic, just hard‑coded, FYI. Please verify this yourself when you get a chance.

Therefore, there is no need for code updates.



## Reproducibility Checklist

- [x] The dependencies required to run the code in this pull request have been added to the project Dockerfile.

## Documentation Checklist


- [x] This analysis module has a `README` and it is up to date.
- [x] The analytical code is documented and contains comments.
